### PR TITLE
fix: Add XDG_RUNTIME_DIR for systemd user session

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,23 +38,30 @@ jobs:
 
       - name: Generate systemd service file from template
         run: |
+          export XDG_RUNTIME_DIR=/run/user/$(id -u)
           sed "s|{{PROJECT_DIR}}|$GITHUB_WORKSPACE|g" \
             systemd/mcp-gpt-expert.service.template > \
             ~/.config/systemd/user/mcp-gpt-expert.service
 
       - name: Reload systemd
-        run: systemctl --user daemon-reload
+        run: |
+          export XDG_RUNTIME_DIR=/run/user/$(id -u)
+          systemctl --user daemon-reload
 
       - name: Restart service
         run: |
+          export XDG_RUNTIME_DIR=/run/user/$(id -u)
           systemctl --user enable mcp-gpt-expert
           systemctl --user restart mcp-gpt-expert
 
       - name: Check service status
-        run: systemctl --user status mcp-gpt-expert --no-pager
+        run: |
+          export XDG_RUNTIME_DIR=/run/user/$(id -u)
+          systemctl --user status mcp-gpt-expert --no-pager
 
       - name: Deployment summary
         run: |
+          export XDG_RUNTIME_DIR=/run/user/$(id -u)
           echo "✅ Deployment completed successfully!"
           echo "Service: mcp-gpt-expert"
           echo "Status: $(systemctl --user is-active mcp-gpt-expert)"


### PR DESCRIPTION
## Problem
GitHub Actions deployment was failing with:
```
Failed to connect to bus: No medium found
```

This occurred because the self-hosted runner (system service) couldn't access the user's D-Bus session.

## Solution
1. **Enabled lingering** for user `shogo`:
   - `loginctl enable-linger shogo`
   - Maintains user session even after logout
   - Allows systemctl --user to work from system services

2. **Added `XDG_RUNTIME_DIR` to all systemd commands**:
   - Export `XDG_RUNTIME_DIR=/run/user/$(id -u)` before each `systemctl --user` command
   - Provides D-Bus connection path for user session

## Changes
- Updated `.github/workflows/deploy.yml`:
  - Generate systemd service file from template (with XDG_RUNTIME_DIR)
  - Reload systemd (with XDG_RUNTIME_DIR)
  - Restart service (with XDG_RUNTIME_DIR)
  - Check service status (with XDG_RUNTIME_DIR)
  - Deployment summary (with XDG_RUNTIME_DIR)

## Why This Approach?
- ✅ **Security**: Maintains user service isolation (minimum privileges)
- ✅ **Standard**: lingering is commonly used for user services
- ✅ **Minimal changes**: No runner reinstallation needed
- ✅ **Reliable**: User session always available

## Testing
After merge, the deployment workflow should complete successfully and the MCP server should run as a user service.

Fixes the deployment failure from #2